### PR TITLE
Fix doc push error

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,11 +104,11 @@ module.exports = function push(url, source, options, callback) {
         return callback(err);
       }
 
-      if (!doc._id) {
+      if (!doc.doc._id) {
         return callback({ error: 'missing_id', reason: 'Missing _id property' });
       }
 
-      getDoc(doc, attachments);
+      getDoc(doc.doc, attachments);
     });
   }
 


### PR DESCRIPTION
Trying to push a JSON document with identical contents to `test/fixtures/doc.json` was failing, due to a "missing_id" error.  This is because it is looking for the `_id` property on the `doc` object - however, `doc` is actually a wrapper object with a property called `doc` that contains the actual document.  The fix uses the nested document to check for the presence of _id.
