### PR TITLE
Updated nano-option to version 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "couchdb-compile": "1.6.0",
     "couchdb-ensure": "1.2.1",
     "minimist": "1.2.0",
-    "nano-option": "1.0.0"
+    "nano-option": "1.1.0"
   },
   "devDependencies": {
     "tap": "0.4.13",


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>