### PR TITLE
Fix watch option

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ module.exports = function push (db, source, options, callback) {
 
     if (options.watch) {
       var queue = async.queue(function (task, done) {
-        console.log('task:', task)
+        console.log(task.type + ': ' + task.filepath)
         compileDoc(function (error, response) {
           error ? console.error(error)
             : console.log(JSON.stringify(response, null, '  '))

--- a/index.js
+++ b/index.js
@@ -157,7 +157,6 @@ module.exports = function push (db, source, options, callback) {
 
     if (options.watch) {
       var queue = async.queue(function (task, done) {
-        console.log(task.type + ': ' + task.filepath)
         compileDoc(function (error, response) {
           error ? console.error(error)
             : console.log(JSON.stringify(response, null, '  '))
@@ -167,12 +166,8 @@ module.exports = function push (db, source, options, callback) {
 
       chokidar
         .watch(source, { ignoreInitial: true, awaitWriteFinish: true })
-        .on('all', function (type, filepath, fileinfo) {
-          queue.push({
-            type: type,
-            filepath: filepath,
-            fileinfo: fileinfo
-          })
+        .on('all', function () {
+          queue.push(true)
         })
     }
 

--- a/index.js
+++ b/index.js
@@ -157,6 +157,7 @@ module.exports = function push (db, source, options, callback) {
 
     if (options.watch) {
       var queue = async.queue(function (task, done) {
+        console.log('typeof task', typeof task)
         compileDoc(function (error, response) {
           error ? console.error(error)
             : console.log(JSON.stringify(response, null, '  '))
@@ -166,7 +167,13 @@ module.exports = function push (db, source, options, callback) {
 
       chokidar
         .watch(source, { ignoreInitial: true })
-        .on('all', queue.push)
+        .on('all', function (a, b, c, d) {
+          console.log('a:', a)
+          console.log('b:', b)
+          console.log('c:', c)
+          console.log('d:', d)
+          queue.push(a)
+        })
     }
 
     compileDoc(callback)

--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ module.exports = function push (db, source, options, callback) {
 
     if (options.watch) {
       var queue = async.queue(function (task, done) {
-        console.log('typeof task', typeof task)
+        console.log('task:', task)
         compileDoc(function (error, response) {
           error ? console.error(error)
             : console.log(JSON.stringify(response, null, '  '))
@@ -166,13 +166,13 @@ module.exports = function push (db, source, options, callback) {
       }, 1)
 
       chokidar
-        .watch(source, { ignoreInitial: true })
-        .on('all', function (a, b, c, d) {
-          console.log('a:', a)
-          console.log('b:', b)
-          console.log('c:', c)
-          console.log('d:', d)
-          queue.push(a)
+        .watch(source, { ignoreInitial: true, awaitWriteFinish: true })
+        .on('all', function (type, filepath, fileinfo) {
+          queue.push({
+            type: type,
+            filepath: filepath,
+            fileinfo: fileinfo
+          })
         })
     }
 


### PR DESCRIPTION
The watch option had a bug that took me a little while to understand.

```
/home/millette/marco/docza/node_modules/async/lib/async.js:862
                throw new Error("task callback must be a function");
                ^
Error: task callback must be a function
```

The problem was https://github.com/jo/couchdb-push/blob/master/index.js#L169
```
 .on('all', queue.push)
```

queue.push expects its second argument to be a callback according to https://github.com/caolan/async/tree/v1.5.2#queueworker-concurrency but chokidar.on('all', cb) sends three arguments, none of which is a callback.
